### PR TITLE
fix: add search path

### DIFF
--- a/lib/decidim/mkutano_custom_registration_flow/middleware/registered_only.rb
+++ b/lib/decidim/mkutano_custom_registration_flow/middleware/registered_only.rb
@@ -23,7 +23,7 @@ module Decidim
           end
 
           def blocked_path?(path)
-            ["/assemblies","/processes", "/consultations", "/conferences", "/meetings"].any? {|blocked_path| path.start_with?(blocked_path) }
+            ["/assemblies","/processes", "/consultations", "/conferences", "/meetings", "/search"].any? {|blocked_path| path.start_with?(blocked_path) }
           end
       end
     end

--- a/lib/decidim/mkutano_custom_registration_flow/middleware/verified_only.rb
+++ b/lib/decidim/mkutano_custom_registration_flow/middleware/verified_only.rb
@@ -28,7 +28,7 @@ module Decidim
           end
 
           def blocked_path?(path)
-            ["/assemblies","/processes", "/consultations", "/conferences", "/meetings"].any? {|blocked_path| path.start_with?(blocked_path) }
+            ["/assemblies","/processes", "/consultations", "/conferences", "/meetings", "/search"].any? {|blocked_path| path.start_with?(blocked_path) }
           end
       end
     end


### PR DESCRIPTION
Adding the search path in the blocked paths, so only registered and verified users are able to search